### PR TITLE
Use fixed randomSeed=0 for conformer embedding when cleaning structures

### DIFF
--- a/dp5/run/mol_file_preparation.py
+++ b/dp5/run/mol_file_preparation.py
@@ -37,7 +37,7 @@ def cleanup_3d(mol):
     - a reasonable conformer
     """
     mol = AllChem.AddHs(mol, addCoords=True)
-    cid = AllChem.EmbedMolecule(mol)
+    cid = AllChem.EmbedMolecule(mol, randomSeed=0)
     if cid == -1:
         raise ValueError("Molecule could not be sanitised")
     AllChem.MMFFOptimizeMolecule(mol)
@@ -146,7 +146,7 @@ def _generate_diastereomers(
         target_mol, options=enum_opts
     ):
         isomer.RemoveAllConformers()
-        cid = Chem.rdDistGeom.EmbedMolecule(isomer)
+        cid = Chem.rdDistGeom.EmbedMolecule(isomer, randomSeed=0)
         if cid >= 0:
             AllChem.MMFFOptimizeMolecule(isomer)
             Chem.rdmolops.AssignStereochemistryFrom3D(isomer)


### PR DESCRIPTION
Without setting randomSeed, the seed is advanced for every call to the EmbedMolecule() function. So e.g. running a DP5 calculation of molecule B on its own gives a different result to running a calculation on A and B at the same time. Setting randomSeed = 0 for every call fixes this