### PR TITLE
Speed up pydp4 help startup and clarify uv install flow

### DIFF
--- a/dp5/load_config.py
+++ b/dp5/load_config.py
@@ -16,8 +16,6 @@ import logging
 import tomli
 import json
 
-from dp5.run import prepare_inputs
-from .runner import runner
 from .logger import setup_logger
 
 LOGLEVEL_CHOICES = tuple(level.lower() for level in logging._nameToLevel.keys())
@@ -99,6 +97,10 @@ def main():
     parser.add_argument("--log_level", choices=LOGLEVEL_CHOICES)
 
     args = parser.parse_args()
+
+    # Delay heavy imports until after CLI parsing so `pydp4 -h` returns quickly.
+    from dp5.run import prepare_inputs
+    from .runner import runner
 
     # load custom configuration
     config_path = (Path.cwd() / args.config).resolve()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "DP5"
 version = "0.1"
 requires-python = ">=3.9, <=3.11"
 description = "A short description of the project"
-readme = "README.md"
+readme = "readme.md"
 authors = [
     {name = "Kristaps Ermanis"},
     {name = "Alexander Howarth"}

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,17 @@
 An improved version of DP5 analysis developed by Howarth (DOI:[10.1039/D1SC04406K](https://doi.org/10.1039/D1SC04406K)). This codebase is refactored for legibility and maintainability.
 
 We strongly recommend using a separate python environment created via `conda`, `uv`, or other solution of your choice to run this programme.
+DP5 currently supports `python>=3.9,<=3.11` (due to the TensorFlow dependency range).
+
+If you do not have `uv` installed yet:
+- macOS (Homebrew): `brew install uv`
+- Linux: `curl -LsSf https://astral.sh/uv/install.sh | sh` (or `wget -qO- https://astral.sh/uv/install.sh | sh`)
 
 To get started:
 - clone this repository using `git clone https://github.com/ruslankotl/DP5.git`
 - navigate to the folder on your machine
-- install via `pip install -e .`
+- create and activate a compatible environment, for example `uv venv --python 3.10 .venv && source .venv/bin/activate`
+- install via `uv pip install -e .` 
 - run `pydp4 -s <SD_FILE> -n <NMR_FILE> -w w`
 
 NMR files are provided as a list of shifts with assignments, e.g., `


### PR DESCRIPTION
## Summary
- defer heavy workflow imports in `dp5/load_config.py` until after `parse_args()` so `pydp4 -h` does not import TensorFlow/statsmodels paths
- fix `pyproject.toml` readme path casing (`readme.md`)
- update README with supported Python range, uv installation commands (macOS/Linux), and `uv pip install -e .` install command

## Validation
- before: `/usr/bin/time -p .venv/bin/pydp4 -h` took ~6.37s
- after: `/usr/bin/time -p .venv/bin/pydp4 -h` takes ~0.07s
- `.venv/bin/python -m dp5.load_config -h` succeeds
